### PR TITLE
Add responsive grid layout

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -1,0 +1,40 @@
+.recipe-grid {
+  display: grid;
+  gap: var(--spacing-400);
+}
+
+@media (min-width: 48rem) {
+  .recipe-grid {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "image header"
+      "image preparation"
+      "image ingredients"
+      "image instructions"
+      "image nutrition";
+  }
+
+  .recipe-grid img {
+    grid-area: image;
+  }
+
+  .recipe-grid .recipe-header {
+    grid-area: header;
+  }
+
+  .recipe-grid .preparation {
+    grid-area: preparation;
+  }
+
+  .recipe-grid .ingredients {
+    grid-area: ingredients;
+  }
+
+  .recipe-grid .instructions {
+    grid-area: instructions;
+  }
+
+  .recipe-grid .nutrition {
+    grid-area: nutrition;
+  }
+}

--- a/css/spacing.css
+++ b/css/spacing.css
@@ -37,6 +37,8 @@ section.nutrition {
 }
 
 main {
-  width: 736px;
+  max-width: 736px;
+  width: 100%;
   padding: var(--spacing-500);
+  margin: 0 auto;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -3,8 +3,9 @@ body {
 }
 
 img {
-  width: 656px;
-  height: 300px;
+  width: 100%;
+  height: auto;
+  max-width: 656px;
   border-radius: 12px;
 }
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/colors.css" />
     <link rel="stylesheet" href="css/fonts.css" />
+    <link rel="stylesheet" href="css/grid.css" />
     <link rel="stylesheet" href="css/table.css" />
     <link rel="stylesheet" href="css/spacing.css" />
     <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- implement `.recipe-grid` CSS grid with desktop columns
- make `main` container responsive and center on the page
- remove fixed image dimensions for flexibility
- include `grid.css` in the page head

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6853f3877ac48330bc42456fc07aef1d